### PR TITLE
Update roadmaps for 2026 and enable Vitepress search

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -45,6 +45,10 @@ export default defineConfig({
     footer: {
       message: 'Lançado sob a licença MIT.',
       copyright: 'Copyright © 2026 Roadmap Developer'
+    },
+
+    search: {
+      provider: 'local'
     }
   }
 })

--- a/roadmaps/backend/backend.md
+++ b/roadmaps/backend/backend.md
@@ -25,7 +25,7 @@ Não tente aprender tudo de uma vez. Escolha uma stack e aprofunde-se.
   - **Foco:** Assincronismo, Event Loop e APIs REST.
 - **Python:**
   - **Frameworks:** Flask (minimalista) ou FastAPI (moderno e rápido).
-  - **Foco:** Essencial para quem quer migrar para IA no futuro.
+  - **Foco:** A linguagem da IA. Mesmo que não seja sua stack principal, aprenda o básico para interagir com scripts de Data Science e modelos de IA.
 - **Java:**
   - **Frameworks:** Spring Boot (padrão de mercado).
   - **Foco:** Tipagem forte, estrutura robusta e ecossistema corporativo.

--- a/roadmaps/frontend/frontend.md
+++ b/roadmaps/frontend/frontend.md
@@ -63,6 +63,7 @@ Onde a engenharia de software encontra a arte e a inteligência artificial.
 ### 🏗️ Arquitetura de Frontend
 - **Micro-frontends:** Module Federation. Como dividir um sistema gigante em partes menores.
 - **Server Components (RSC):** O novo paradigma do React e Next.js. Renderizar no servidor o que não precisa de interatividade.
+- **Server Actions:** O padrão recomendado para executar mutações de dados e operações de IA (como chamar a OpenAI) de forma segura a partir do frontend, sem expor chaves de API.
 - **Performance:** Core Web Vitals (LCP, CLS, INP). Otimização extrema com Code Splitting e Lazy Loading.
 
 ### 🤖 IA Engineering no Frontend (O Diferencial de 2026)

--- a/roadmaps/mobile/mobile.md
+++ b/roadmaps/mobile/mobile.md
@@ -70,7 +70,10 @@ Otimização extrema, arquitetura limpa e Inteligência Artificial no dispositiv
 
 ### 📱 IA no Mobile (On-Device AI - A Nova Era)
 - **Small Language Models (SLMs):** Rodar Phi-3, Gemma ou Llama 3 8B direto no celular.
-- **ExecuTorch & TFLite:** Frameworks para otimizar e rodar modelos PyTorch e TensorFlow no edge.
+- **Frameworks de IA:**
+  - **ExecuTorch & TFLite:** Para rodar modelos PyTorch e TensorFlow no edge.
+  - **MediaPipe:** Soluções prontas do Google para Visão Computacional e ML on-device.
+  - **CoreML:** O framework nativo da Apple para máxima performance no iOS.
 - **NPU Acceleration:** Delegar o processamento de IA para o chip neural (Apple Neural Engine / Android NPU) para economizar bateria.
 - **Privacidade (Local RAG):** Usar dados pessoais do dispositivo para dar contexto à IA, sem nunca enviar os dados para a nuvem.
 


### PR DESCRIPTION
Updated roadmaps (Backend, Frontend, Mobile) with high-quality content focused on AI Engineering, On-Device AI, and Server Actions. Enabled local search in Vitepress configuration.

---
*PR created automatically by Jules for task [261806567933714621](https://jules.google.com/task/261806567933714621) started by @juninmd*