### PR TITLE
Update Roadmaps for 2026 and Verify VitePress Site

### DIFF
--- a/roadmaps/backend/backend.md
+++ b/roadmaps/backend/backend.md
@@ -48,6 +48,9 @@ Não tente aprender tudo de uma vez. Escolha uma stack e aprofunde-se.
   - **Foco:** Tipagem forte, estrutura robusta e ecossistema corporativo.
 - **Go:**
   - **Foco:** Concorrência, simplicidade e alta performance para microsserviços.
+- **Rust:**
+  - **Frameworks:** Actix-web ou Axum.
+  - **Foco:** Performance extrema, segurança de memória e ferramentas de infraestrutura. A escolha para quem quer o máximo de controle.
 
 ### 🔌 APIs RESTful
 - Entenda os verbos HTTP (GET, POST, PUT, DELETE).

--- a/roadmaps/frontend/frontend.md
+++ b/roadmaps/frontend/frontend.md
@@ -79,6 +79,7 @@ Onde a engenharia de software encontra a arte e a inteligência artificial.
 - **Micro-frontends:** Module Federation. Como dividir um sistema gigante em partes menores.
 - **Server Components (RSC):** O novo paradigma do React e Next.js. Renderizar no servidor o que não precisa de interatividade.
 - **Server Actions:** O padrão recomendado para executar mutações de dados e operações de IA (como chamar a OpenAI) de forma segura a partir do frontend, sem expor chaves de API.
+- **Server-Driven UI (HTMX):** A alternativa radical às SPAs complexas. Retornar HTML do servidor em vez de JSON, ideal para aplicações "dashboard-like" e redução de complexidade.
 - **Performance:** Core Web Vitals (LCP, CLS, INP). Otimização extrema com Code Splitting e Lazy Loading.
 
 ### 🤖 IA Engineering no Frontend (O Diferencial de 2026)

--- a/roadmaps/mobile/mobile.md
+++ b/roadmaps/mobile/mobile.md
@@ -32,9 +32,10 @@ Comece entendendo como os apps funcionam e publique seu primeiro "Hello World".
 - **Nativo (Especialista):**
   - **Android (Kotlin):** O padrão moderno do Google.
   - **iOS (Swift):** A linguagem elegante da Apple.
-- **Híbrido (Multiplataforma):**
+- **Híbrido & Multiplataforma:**
   - **React Native:** Use seus conhecimentos de web (JavaScript/React).
   - **Flutter:** Desenhe em qualquer pixel com Dart. Alta performance.
+  - **Kotlin Multiplatform (KMP):** Compartilhe a lógica de negócios (e até UI com Compose Multiplatform) mantendo a performance 100% nativa.
 
 ### 🧩 Fundamentos de UI/UX Mobile
 - **Layouts:** Flexbox (React Native), Rows/Columns (Flutter) ou AutoLayout (iOS). Como criar telas responsivas.


### PR DESCRIPTION
Updates the developer roadmaps with specific 2026 trends including Kotlin Multiplatform, Rust, and HTMX. Verified that the VitePress site builds correctly with these changes.

---
*PR created automatically by Jules for task [2631016656031631207](https://jules.google.com/task/2631016656031631207) started by @juninmd*