### PR TITLE
Update Developer Roadmaps for 2026

### DIFF
--- a/roadmaps/backend/backend.md
+++ b/roadmaps/backend/backend.md
@@ -131,6 +131,11 @@ O Backend agora precisa saber servir IA, não apenas JSON.
   - Rodar modelos locais (Llama 3, Mistral, Gemma) usando **Ollama** ou **vLLM**.
   - **Fine-tuning eficiente:** Ajustar modelos pequenos para tarefas específicas do seu negócio.
 
+### 📚 Livros e Leituras Obrigatórias (Sênior)
+Para chegar ao nível especialista, a prática não basta. Você precisa de teoria sólida.
+- **"Designing Data-Intensive Applications" (Martin Kleppmann):** A bíblia dos sistemas distribuídos. Entenda como bancos de dados realmente funcionam (B-Trees, SSTables, Replication, Partitioning).
+- **"System Design Primer":** O guia definitivo para entender como projetar sistemas que aguentam milhões de usuários.
+
 ---
 
 ## ↩️ Navegação

--- a/roadmaps/devops/devops.md
+++ b/roadmaps/devops/devops.md
@@ -92,6 +92,12 @@ Onde você constrói plataformas para outros desenvolvedores e garante a estabil
 - **Secret Management:** Vault. Nunca commite senhas no Git.
 - **Supply Chain Security:** Assinar imagens e verificar dependências (SBOM - Software Bill of Materials).
 
+### 📚 Livros e Cultura (Leitura Obrigatória)
+DevOps é cultura, e cultura se aprende com histórias e práticas.
+- **"The Phoenix Project" (Gene Kim):** Um romance (sim, uma história!) que explica porque o trabalho de TI costuma ser caótico e como o DevOps resolve isso. Leitura leve e essencial.
+- **"The DevOps Handbook":** O manual prático que segue o "Phoenix Project".
+- **"Site Reliability Engineering" (Google):** Como o Google mantém seus sistemas no ar. O nascimento do conceito de SRE.
+
 ---
 
 ## ↩️ Navegação

--- a/roadmaps/mobile/mobile.md
+++ b/roadmaps/mobile/mobile.md
@@ -98,6 +98,11 @@ Otimização extrema, arquitetura limpa e Inteligência Artificial no dispositiv
 - **Voice UI:** Integração com Whisper local para comandos de voz rápidos.
 - **Multimodalidade:** Usar a câmera para analisar objetos e textos em tempo real.
 
+### 🎓 Recursos Oficiais (A Verdade Direta da Fonte)
+Em mobile, as coisas mudam todo ano nas conferências oficiais. Acompanhe:
+- **Android Developers (YouTube):** O canal oficial. Assista aos vídeos da *Google I/O* todo ano.
+- **Apple Developer (WWDC):** Instale o app "Developer" da Apple. Assista às sessões da *WWDC* para saber o que há de novo no Swift e SwiftUI.
+
 ---
 
 ## ↩️ Navegação


### PR DESCRIPTION
Updated the developer roadmaps (Backend, DevOps, Mobile) to include high-quality, essential learning resources for 2026. This includes standard industry books for Senior Backend and DevOps engineers, and official conference channels for Mobile developers. Verified that the VitePress site builds correctly with these changes.

---
*PR created automatically by Jules for task [17546714955090238906](https://jules.google.com/task/17546714955090238906) started by @juninmd*