### PR TITLE
Update Roadmaps for 2026 Standards

### DIFF
--- a/index.md
+++ b/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: Roadmap Developer 2026
   text: O Guia Definitivo para sua Carreira
-  tagline: Trilhas de estudo completas e atualizadas para formar desenvolvedores de elite em 2026.
+  tagline: Trilhas de estudo completas e atualizadas para formar desenvolvedores de elite na Era da IA.
   image:
     src: https://github.blog/wp-content/uploads/2012/03/codercat.jpg?fit=896%2C896
     alt: Coder Cat
@@ -17,41 +17,48 @@ hero:
       link: /roadmaps/backend/backend
 
 features:
-  - title: Frontend
-    details: Domine React, Next.js, Generative UI e WebGPU.
+  - title: Frontend 2026
+    details: Domine React, Next.js, Generative UI, Server Actions e WebGPU.
     link: /roadmaps/frontend/frontend
-  - title: Backend
-    details: Arquitetura, Microsserviços, IA e Engenharia de Dados.
+  - title: Backend Moderno
+    details: Arquitetura, Microsserviços, Green Software e Engenharia de IA.
     link: /roadmaps/backend/backend
-  - title: Mobile
-    details: Apps Nativos, Híbridos e IA no Dispositivo (On-Device AI).
+  - title: Mobile & Edge AI
+    details: Apps Nativos, KMP e IA rodando no dispositivo (On-Device AI).
     link: /roadmaps/mobile/mobile
-  - title: DevOps
-    details: Platform Engineering, GitOps e Observabilidade.
+  - title: DevOps & Platform
+    details: Platform Engineering, GitOps, FinOps e Observabilidade com IA.
     link: /roadmaps/devops/devops
   - title: Inteligência Artificial
-    details: De RAG Avançado a Agentes Autônomos e LLMOps.
+    details: De RAG Avançado e Agentes Autônomos a LLMOps e Fine-Tuning.
     link: /roadmaps/ai/artificial-intelligence
 ---
 
-# Sobre o Roadmap
+# 🚀 Por que este Roadmap?
 
-Este projeto visa auxiliar quem está iniciando ou quer se especializar no desenvolvimento de software, trazendo o que há de mais moderno para o mercado em 2026.
+O mercado mudou. O que era "sênior" em 2023 é "básico" em 2026. A Inteligência Artificial não é mais um diferencial, é um pré-requisito.
 
-## Por onde começar?
+Este projeto não é apenas uma lista de tecnologias. É um guia curado para formar **Engenheiros de Software Completos**, preparados para:
+*   **Trabalhar com Agentes de IA** como pares.
+*   **Construir Sistemas Sustentáveis** (Green Software).
+*   **Focar na Experiência do Usuário** enquanto a IA escreve o boilerplate.
 
-1.  **[Trilha em comum](/roadmaps/general/common)**: O básico que todo dev precisa saber (Git, Lógica, IA Literacy).
-2.  Escolha sua especialização:
-    *   [Backend](/roadmaps/backend/backend)
-    *   [Frontend](/roadmaps/frontend/frontend)
-    *   [Mobile](/roadmaps/mobile/mobile)
-    *   [DevOps](/roadmaps/devops/devops)
-    *   [Inteligência Artificial](/roadmaps/ai/artificial-intelligence)
+## 🗺️ Sua Jornada Começa Aqui
 
-## Conselhos
+1.  **[Trilha Comum (Base)](/roadmaps/general/common)**: O básico que todo dev precisa saber (Git, Lógica, IA Literacy). **Obrigatório para todos.**
+2.  **Escolha sua Especialização:**
+    *   [Backend](/roadmaps/backend/backend): Para quem gosta de lógica, dados e sistemas robustos.
+    *   [Frontend](/roadmaps/frontend/frontend): Para quem ama criar interfaces incríveis e performáticas.
+    *   [Mobile](/roadmaps/mobile/mobile): Para quem quer colocar o mundo na palma da mão.
+    *   [DevOps](/roadmaps/devops/devops): Para os guardiões da infraestrutura e automação.
+    *   [Inteligência Artificial](/roadmaps/ai/artificial-intelligence): Para os arquitetos da nova era.
 
-Para dicas sobre carreira, síndrome do impostor e como estudar, confira a página de [Conselhos](/advices).
+## 💡 Conselhos de Carreira
 
+Não sabe por onde começar? Sente que não sabe nada (Síndrome do Impostor)?
+Confira nossa página de [**Conselhos**](/advices) para um guia mental de sobrevivência.
+
+---
 ## Créditos
 
 Inspirado em: [Roadmap.sh](https://roadmap.sh/)

--- a/roadmaps/backend/backend.md
+++ b/roadmaps/backend/backend.md
@@ -103,6 +103,12 @@ Onde você projeta sistemas complexos, escaláveis e inteligentes.
 - **Serverless:** AWS Lambda, Cloudflare Workers. Foco no código, zero infra.
 - **Event-Driven Architecture:** Kafka e sistemas reativos para alto volume de dados.
 
+### 📊 Engenharia de Dados para Devs
+O Backend moderno lida com pipelines de dados, não apenas CRUD.
+- **ETL vs ELT:** Extrair, Transformar e Carregar. Ferramentas como **dbt** (data build tool) são padrão de mercado.
+- **Data Warehouses:** Snowflake, BigQuery. Entenda a diferença para um banco tradicional (OLTP vs OLAP).
+- **Data Lakes:** Onde jogamos dados brutos (S3, Parquet) para a IA consumir depois.
+
 ### 🔭 Observabilidade (OpenTelemetry)
 O "Olho de Sauron" para o bem.
 - **Pilares:** Logging, Métricas e Tracing Distribuído.
@@ -136,6 +142,11 @@ O Backend agora precisa saber servir IA, não apenas JSON.
 Para chegar ao nível especialista, a prática não basta. Você precisa de teoria sólida.
 - **"Designing Data-Intensive Applications" (Martin Kleppmann):** A bíblia dos sistemas distribuídos. Entenda como bancos de dados realmente funcionam (B-Trees, SSTables, Replication, Partitioning).
 - **"System Design Primer":** O guia definitivo para entender como projetar sistemas que aguentam milhões de usuários.
+
+### 📺 Canais de System Design (YouTube)
+- **ByteByteGo (Alex Xu):** As melhores explicações visuais de sistemas complexos (YouTube e Newsletter).
+- **Hussein Nasser:** Engenharia de Backend pura e profunda (Protocolos, Database Internals).
+- **Arpit Bhayani:** System Design para o mundo real e alta escala.
 
 ---
 

--- a/roadmaps/devops/devops.md
+++ b/roadmaps/devops/devops.md
@@ -87,10 +87,18 @@ Onde você constrói plataformas para outros desenvolvedores e garante a estabil
 - **Internal Developer Platforms (IDP):** Construir portais (como **Backstage**) para que devs criem serviços padronizados com um clique ("Paved Roads").
 - **Self-Service:** O dev não deve abrir ticket para pedir um banco de dados; ele deve provisionar via plataforma.
 
-### 💰 FinOps & Segurança (DevSecOps)
-- **FinOps:** Monitorar e otimizar custos de nuvem. "Desligue o que não usa".
-- **Secret Management:** Vault. Nunca commite senhas no Git.
-- **Supply Chain Security:** Assinar imagens e verificar dependências (SBOM - Software Bill of Materials).
+### 🛡️ DevSecOps: Segurança desde o Dia 1
+Segurança não é responsabilidade só do time de InfoSec no final do projeto.
+- **SAST & DAST:** Análise estática (SonarQube) e dinâmica de vulnerabilidades.
+- **Container Scanning:** Nunca suba uma imagem Docker sem passar pelo **Trivy** ou **Grype** para achar CVEs.
+- **Policy as Code:** Use **OPA (Open Policy Agent)** para impedir deploys inseguros (ex: bloquear containers rodando como root).
+- **Supply Chain Security:** Assinar imagens (Cosign) e verificar dependências (SBOM - Software Bill of Materials) para evitar ataques à cadeia de suprimentos.
+- **Secret Management:** HashiCorp Vault ou AWS Secrets Manager. Nunca commite senhas no Git (`.env` no `.gitignore` sempre!).
+
+### 💰 FinOps: O Custo é um Requisito
+- **Monitoramento de Custos:** Use **Kubecost** ou AWS Cost Explorer. Se você não mede, você não controla.
+- **Rightsizing:** Ajustar CPU/RAM dos pods para o uso real. Não use um canhão para matar uma mosca.
+- **Spot Instances:** Usar máquinas ociosas da nuvem com até 90% de desconto para workloads que podem ser interrompidos.
 
 ### 📚 Livros e Cultura (Leitura Obrigatória)
 DevOps é cultura, e cultura se aprende com histórias e práticas.

--- a/roadmaps/frontend/frontend.md
+++ b/roadmaps/frontend/frontend.md
@@ -69,6 +69,15 @@ Quando passar props de pai para filho fica insustentável.
 - **Tailwind CSS:** O padrão moderno de estilização utilitária.
 - **Component Libraries:** Não reinvente a roda. Use **shadcn/ui** ou **Radix UI** para componentes acessíveis e bonitos.
 
+### ♿ Acessibilidade Web (a11y)
+A internet deve ser para todos.
+- **Semântica HTML:** `button` é botão, `div` não é botão. O básico que muitos erram.
+- **WAI-ARIA:** Quando o HTML não basta, use atributos ARIA (`aria-label`, `role`) para guiar leitores de tela.
+- **Ferramentas de Auditoria:**
+  - **Lighthouse / WAVE:** Para checkups rápidos.
+  - **axe-core:** Para automação de testes de acessibilidade.
+  - **Leitores de Tela (NVDA / VoiceOver):** Teste seu site de olhos fechados.
+
 ---
 
 ## 🧙‍♂️ Nível Avançado (Sênior / Especialista)
@@ -80,7 +89,13 @@ Onde a engenharia de software encontra a arte e a inteligência artificial.
 - **Server Components (RSC):** O novo paradigma do React e Next.js. Renderizar no servidor o que não precisa de interatividade.
 - **Server Actions:** O padrão recomendado para executar mutações de dados e operações de IA (como chamar a OpenAI) de forma segura a partir do frontend, sem expor chaves de API.
 - **Server-Driven UI (HTMX):** A alternativa radical às SPAs complexas. Retornar HTML do servidor em vez de JSON, ideal para aplicações "dashboard-like" e redução de complexidade.
-- **Performance:** Core Web Vitals (LCP, CLS, INP). Otimização extrema com Code Splitting e Lazy Loading.
+
+### ⚡ Performance & Core Web Vitals
+Performance é UX. Ninguém gosta de site lento.
+- **LCP (Largest Contentful Paint):** Quanto tempo demora para o "conteúdo principal" aparecer? Meta: < 2.5s.
+- **INP (Interaction to Next Paint):** O site trava quando clico? Substituiu o FID. Meta: < 200ms.
+- **CLS (Cumulative Layout Shift):** As coisas mudam de lugar sozinhas? Evite layout instável.
+- **Técnicas:** Code Splitting, Lazy Loading de imagens, otimização de fontes e uso correto de Cache-Control.
 
 ### 🤖 IA Engineering no Frontend (O Diferencial de 2026)
 - **Vercel AI SDK:** A ponte entre seu frontend e os LLMs. Streaming de texto e chat.

--- a/roadmaps/general/common.md
+++ b/roadmaps/general/common.md
@@ -205,6 +205,29 @@ A Inteligência Artificial não vai substituir os desenvolvedores, mas os desenv
 
 ---
 
+### 🧠 Aprender a Aprender: O Meta-Skill
+
+Em um mundo onde a tecnologia muda toda semana, saber *como* aprender é mais importante do que *o que* você aprende.
+
+- **Técnica Pomodoro:** Foco total por 25 minutos, descanso de 5. Ajuda a evitar distrações e manter a mente fresca.
+- **Spaced Repetition (Repetição Espaçada):** O cérebro esquece rápido. Use ferramentas como **Anki** para revisar conceitos (flashcards) em intervalos crescentes (hoje, amanhã, semana que vem). É a melhor forma de fixar sintaxe e comandos.
+- **Active Recall (Recordação Ativa):** Não apenas leia. Feche o livro e tente explicar o conceito em voz alta. Se você não consegue explicar, você não entendeu.
+- **Deep Work (Trabalho Profundo):** Reserve blocos de 2 a 4 horas sem celular, sem Slack e sem interrupções. É onde a mágica complexa acontece.
+- **Recurso:** 📖 [Learning How to Learn (Coursera)](https://www.coursera.org/learn/learning-how-to-learn) - O curso mais popular do mundo sobre o tema.
+
+---
+
+### ❤️ Saúde Mental: O Hardware Mais Importante
+
+Seu cérebro é seu computador principal. Se ele pifar (Burnout), não tem peça de reposição.
+
+- **Burnout não é medalha de honra:** Trabalhar 14 horas por dia não te faz um herói, te faz um paciente em potencial.
+- **Descanse de verdade:** Ficar scrollando o TikTok não é descanso. Seu cérebro continua processando informação. Tente caminhar, dormir ou fazer nada.
+- **Hobbies Offline:** Tenha hobbies que não envolvam telas. Cozinhar, tocar música, esportes. Isso ajuda a "resetar" o cérebro.
+- **Dormir é produtivo:** É durante o sono que o cérebro limpa as toxinas e consolida o aprendizado. Dormir pouco te deixa "burro" no dia seguinte.
+
+---
+
 ### 📚 Onde Estudar de Graça (Recursos Gerais)
 
 - **[FreeCodeCamp](https://www.freecodecamp.org/):** O melhor lugar para começar do zero. Cursos interativos e projetos práticos.


### PR DESCRIPTION
This pull request updates the developer roadmaps to align with 2026 standards, focusing on AI Engineering, Green Software, and modern architectural patterns.

**Key Changes:**
1.  **Home Page (`index.md`):** Rewrite of the landing page to highlight the "Era of AI" and the value proposition of the roadmap.
2.  **General Track (`common.md`):** Added critical soft skills: Meta-learning (Pomodoro, Spaced Repetition) and Burnout prevention.
3.  **Backend Track (`backend.md`):** Added a new section on Data Engineering (ETL, dbt) and specific System Design learning resources.
4.  **Frontend Track (`frontend.md`):** Added a dedicated Accessibility section (WAI-ARIA, axe-core) and expanded Performance to include Core Web Vitals (INP, LCP).
5.  **DevOps Track (`devops.md`):** Split "FinOps & Security" into robust "DevSecOps" (SAST/DAST, Policy as Code) and "FinOps" sections.

The site structure remains compatible with VitePress, and all changes have been verified via a local build and frontend screenshot verification.

---
*PR created automatically by Jules for task [4031122286883996749](https://jules.google.com/task/4031122286883996749) started by @juninmd*