### PR TITLE
feat: update roadmap content for 2026

### DIFF
--- a/roadmaps/ai/artificial-intelligence.md
+++ b/roadmaps/ai/artificial-intelligence.md
@@ -97,6 +97,7 @@ O mundo não é feito só de texto. Modelos que veem, ouvem e falam.
 - **Audio Generation:** Text-to-Speech (TTS) e Music Generation. (ElevenLabs, Suno, Udio).
 - **Video Generation:** Sora, Runway Gen-3. A complexidade da consistência temporal.
 - **Vision-Language Models (VLMs):** GPT-4o, LLaVA. Como projetar embeddings de imagem no espaço de texto.
+- **Vision-Language-Action (VLA) Models (Robótica em 2026):** Modelos que além de ver e entender o ambiente, processam e executam as ações mecânicas.
 
 ### ⚙️ MLOps Básico
 Não basta treinar, tem que monitorar.

--- a/roadmaps/backend/backend.md
+++ b/roadmaps/backend/backend.md
@@ -97,7 +97,9 @@ Sistemas distribuídos precisam conversar sem travar.
 
 Onde você projeta sistemas complexos, escaláveis e inteligentes.
 
-### 🏗️ Arquitetura de Software
+### 🏗️ Arquitetura de Software e Alta Performance
+- **Rust & Go para Microsserviços:** Adoção de linguagens compiladas para economizar CPU/Memória na nuvem e entregar APIs super rápidas.
+- **WebAssembly (Wasm) no Backend:** Escrever módulos de código (Rust, Go, C++) que rodam de forma segura e com performance nativa em ambientes Edge e Serverless.
 - **Microsserviços:** Quando usar (e principalmente quando NÃO usar).
 - **Domain-Driven Design (DDD):** Modelando o software de acordo com a complexidade do negócio.
 - **Serverless:** AWS Lambda, Cloudflare Workers. Foco no código, zero infra.

--- a/roadmaps/data/data-engineering.md
+++ b/roadmaps/data/data-engineering.md
@@ -87,10 +87,11 @@ Dados que perdem valor em segundos (fraude, IoT, mercado financeiro).
 - **Apache Kafka:** O backbone de mensagens. Tópicos, Partições, Offsets.
 - **Stream Processing:** Kafka Streams, Apache Flink ou Spark Structured Streaming.
 
-### 🏠 Lakehouse Architecture
-O melhor dos dois mundos (Warehouse + Lake).
-- **Formatos Abertos:** Parquet, Avro, Iceberg, Delta Lake. ACID em cima de object storage (S3).
-- **Medallion Architecture:** Camadas Bronze (Bruto), Silver (Limpo/Enriquecido), Gold (Agregado para BI).
+### 🏠 Lakehouse, Data Mesh e Data Fabric
+A arquitetura não deve ser monolítica e deve focar nas responsabilidades.
+- **Lakehouse:** Formatos abertos (Parquet, Iceberg, Delta Lake) com transações ACID em cima de Object Storage (S3). Implementação da arquitetura medalhão (Bronze, Prata e Ouro).
+- **Data Mesh:** Tratar dados como produtos com donos de diferentes domínios, descentralizando a engenharia de dados, usando conectores interoperáveis para unir toda a malha de conhecimento.
+- **Data Fabric:** Um conjunto de ferramentas para criar, monitorar, governar os fluxos, ajudando a automatizar grande parte dos metadados e descobertas sobre governança na malha.
 
 ### 👮 Governança e DataOps
 - **Catálogo de Dados:** DataHub, Amundsen. Onde está o dado? Quem é o dono?

--- a/roadmaps/devops/devops.md
+++ b/roadmaps/devops/devops.md
@@ -74,7 +74,8 @@ Nunca configure servidores manualmente (ClickOps).
 
 Onde você constrói plataformas para outros desenvolvedores e garante a estabilidade de sistemas globais.
 
-### 🔭 Observabilidade (Não é só Monitoramento)
+### 🔭 Observabilidade e Redes de Nova Geração
+- **eBPF (Extended Berkeley Packet Filter):** Executar programas diretamente no Kernel do Linux, em tempo real, fornecendo métricas profundas, segurança (Cilium) e observabilidade com zero modificação no código ou agentes complexos.
 - **OpenTelemetry:** O padrão para coletar Logs, Métricas e Traces.
 - **Ferramentas:** Prometheus (Métricas), Grafana (Dashboards), Jaeger/Tempo (Tracing).
 - **SLIs, SLOs e SLAs:** Definindo e medindo a confiabilidade do serviço com dados reais.

--- a/roadmaps/frontend/frontend.md
+++ b/roadmaps/frontend/frontend.md
@@ -86,8 +86,9 @@ Onde a engenharia de software encontra a arte e a inteligência artificial.
 
 ### 🏗️ Arquitetura de Frontend
 - **Micro-frontends:** Module Federation. Como dividir um sistema gigante em partes menores.
-- **Server Components (RSC):** O novo paradigma do React e Next.js. Renderizar no servidor o que não precisa de interatividade.
-- **Server Actions:** O padrão recomendado para executar mutações de dados e operações de IA (como chamar a OpenAI) de forma segura a partir do frontend, sem expor chaves de API.
+- **Server Components (RSC) e Next.js 15+:** O paradigma moderno de renderização mista de páginas web.
+  - **Partial Prerendering (PPR):** Combinar uma página estática super rápida com pedaços dinâmicos renderizados via stream, com suspenses.
+- **Server Actions (Avançado):** Lógica que roda no servidor a partir do front end, útil para mutações em bancos de dados ou chamadas de API, garantindo segurança ao invés de expor endpoints.
 - **Server-Driven UI (HTMX):** A alternativa radical às SPAs complexas. Retornar HTML do servidor em vez de JSON, ideal para aplicações "dashboard-like" e redução de complexidade.
 
 ### ⚡ Performance & Core Web Vitals

--- a/roadmaps/fullstack/fullstack.md
+++ b/roadmaps/fullstack/fullstack.md
@@ -81,6 +81,11 @@ Onde você desenha sistemas resilientes e integra Inteligência Artificial.
 - **Serverless vs Edge:** Rodar código perto do usuário (Cloudflare Workers) para latência mínima.
 - **Filas e Jobs:** Tirar tarefas pesadas (envio de email, processamento de imagem) do ciclo de requisição HTTP. (Redis + BullMQ).
 
+### 🌍 Local-First Architecture
+Sistemas onde a fonte da verdade é o cliente e os servidores sincronizam no background.
+- **Offline-First:** O app funciona perfeitamente sem internet (PWA + Bancos de dados locais como Dexie.js ou PouchDB).
+- **CRDTs (Conflict-free Replicated Data Types):** Sincronização automática e resolução de conflitos para colaboração em tempo real (como o Google Docs). Ferramentas como **Yjs** ou **Automerge**.
+
 ### 🤖 Fullstack AI Engineering
 A integração profunda de modelos de IA no produto.
 - **Vercel AI SDK:** O padrão para construir interfaces de chat e streaming de texto/componentes.

--- a/roadmaps/general/common.md
+++ b/roadmaps/general/common.md
@@ -66,6 +66,9 @@ A Inteligência Artificial não vai substituir os desenvolvedores, mas os desenv
   - **Chain of Thought:** Peça para a IA "pensar passo a passo" antes de dar a solução final.
   - **Structured Outputs:** Peça respostas em JSON para integrar com seus scripts.
 - **Agentes e Ferramentas:** Entenda a diferença entre um chatbot (que só fala) e um Agente (que pode executar comandos no terminal, acessar a web e modificar arquivos).
+- **Agentic Coding Workflows (2026):**
+  - **Uso de LLMs como pares:** Ferramentas como o GitHub Copilot Workspace, Aider e SWE-agent mudaram a forma de codar. Você não digita linha por linha, você planeja e o agente escreve, você revisa e orquestra as mudanças.
+  - **Ferramentas:** Dominar a integração do editor de código (Cursor, Windsurf) para que a IA tenha acesso completo ao contexto e árvore de arquivos.
 
 ### 🐧 Linux, Terminal e Sistemas Operacionais
 

--- a/roadmaps/mobile/mobile.md
+++ b/roadmaps/mobile/mobile.md
@@ -77,6 +77,7 @@ Construa apps robustos, que funcionam offline e encantam o usuário.
 Otimização extrema, arquitetura limpa e Inteligência Artificial no dispositivo.
 
 ### 🏗️ Arquitetura Mobile Avançada
+- **Compose Multiplatform (Avançado):** Levar a UI declarativa do Kotlin para além do Android e iOS, compilando telas nativas para Desktop (Mac/Windows) e WebAssembly a partir do mesmo código.
 - **Clean Architecture:** Separação de responsabilidades (Domain, Data, Presentation).
 - **MVVM / MVI:** Padrões unidirecionais para interfaces reativas e testáveis.
 - **Modularização:** Dividir o app em múltiplos pacotes/módulos para acelerar o build e escalar times grandes.


### PR DESCRIPTION
Updates all roadmap Markdown files (Common, Backend, Frontend, Fullstack, Mobile, AI, DevOps, Data) with high-quality content for 2026. This includes additions such as Agentic Coding Workflows, Rust/Wasm in backend, Next.js 15+ in frontend, Local-first/CRDTs in fullstack, Compose Multiplatform in mobile, VLA models in AI, eBPF in DevOps, and Data Mesh/Fabric in Data Engineering. Content covers everything from Junior to Specialist levels.

The site uses the existing VitePress configuration successfully.

---
*PR created automatically by Jules for task [2133256181085736950](https://jules.google.com/task/2133256181085736950) started by @juninmd*