### PR TITLE
Add recommended study resources to all roadmaps

### DIFF
--- a/roadmaps/ai/artificial-intelligence.md
+++ b/roadmaps/ai/artificial-intelligence.md
@@ -184,19 +184,25 @@ Não construa Skynet sem querer.
 ## 🎓 Cursos e Recursos de Estudo (Links Diretos)
 
 ### 🌟 Essenciais e Gratuitos
-- **[Fast.ai (Practical Deep Learning)](https://course.fast.ai/):** A melhor forma de começar "top-down". Codifique primeiro, estude a teoria depois.
-- **[Hugging Face Courses](https://huggingface.co/learn):**
-  - **NLP Course:** Domine Transformers.
-  - **Deep RL Course:** Aprendizado por Reforço.
-  - **Audio Course:** Processamento de áudio.
+
+**Para o Júnior (Matemática Básica, Python, Fundamentos GenAI):**
 - **[DeepLearning.AI (Andrew Ng)](https://www.deeplearning.ai/):**
-  - **AI for Everyone:** Visão geral de negócio.
-  - **Generative AI with LLMs:** Focado em fine-tuning e deployment (AWS).
-  - **Prompt Engineering for Developers:** O curso clássico com a OpenAI.
-  - **AI Agentic Design Patterns with AutoGen:** Entenda os padrões de agentes na prática.
-- **[Cohere LLM University](https://llm.university/):** Ótimo para entender embeddings e busca semântica.
-- **[Full Stack Deep Learning (LLM Bootcamp)](https://fullstackdeeplearning.com/llm-bootcamp/):** O curso definitivo para quem quer colocar LLMs em produção.
-- **[LangChain Academy](https://academy.langchain.com/):** Aprenda a construir aplicações com LangChain e LangGraph.
+  - *AI for Everyone:* Visão geral de negócio que todo iniciante deveria começar.
+  - *Machine Learning Specialization:* Curso introdutório que o ensinará de fato os primeiros passos dos tensores antes dos LLMs.
+- **[Fast.ai (Practical Deep Learning)](https://course.fast.ai/):** A melhor forma de começar "top-down". Codifique primeiro, estude a teoria depois.
+
+**Para o Pleno (Machine Learning, RAG, NLP e Visão Computacional):**
+- **[Hugging Face Courses](https://huggingface.co/learn):**
+  - *NLP Course:* Domine Transformers.
+  - *Deep RL Course:* Aprendizado por Reforço.
+- **[Cohere LLM University](https://llm.university/):** Ótimo para entender a teoria completa dos embeddings, distâncias vetoriais e busca semântica para RAG.
+- **[DeepLearning.AI Short Courses (Grátis)](https://www.deeplearning.ai/short-courses/):** Para aprender *Prompt Engineering for Developers* com OpenAI API de ponta a ponta na prática.
+
+**Para o Sênior/Especialista (LLMOps, Multi-Agents, DSPy, Local-First Models):**
+- **[LangChain Academy](https://academy.langchain.com/):** O curso aprofundado para aprender grafos baseados em estado para orquestrar *Agentic Workflows* através do LangGraph.
+- **[Full Stack Deep Learning (LLM Bootcamp)](https://fullstackdeeplearning.com/llm-bootcamp/):** O curso definitivo para arquitetura corporativa em MLOps e colocar LLMs massivos em produção usando servidores de inferência (vLLM).
+- **[DeepLearning.AI: AI Agentic Design Patterns with AutoGen](https://www.deeplearning.ai/short-courses/ai-agentic-design-patterns-with-autogen/):** Entenda os padrões de agentes (Planning, Tool Use, Reflection) na prática recomendados pelo próprio Andrew Ng.
+- **[Anthropic Prompt Engineering Tutorial](https://github.com/anthropics/courses):** Muito avançado, ensina *Few-shot*, *Chain of Thought* forçados e técnicas obscuras em 2026 para dominar os modelos Claude 3.5 Sonnet.
 
 ### 🎧 Podcasts e Mídia (Engenharia Real)
 - **[Latent Space](https://www.latent.space/):** O melhor podcast de Engenharia de IA. Discussões profundas com os criadores das ferramentas.

--- a/roadmaps/backend/backend.md
+++ b/roadmaps/backend/backend.md
@@ -185,7 +185,7 @@ Para atingir a excelência em 2026, recomendamos os seguintes recursos práticos
 **Para o Júnior (Fundamentos e Bases):**
 - **[Boot.dev](https://www.boot.dev/):** Plataforma incrível gamificada focada no backend (Python, Go, algoritmos e estruturas de dados).
 - **[FreeCodeCamp - Back End Development and APIs](https://www.freecodecamp.org/):** Excelente curso prático e gratuito sobre Node.js e MongoDB.
-- **Documentações Oficiais:** Ler os guias iniciais do Express.js, FastAPI, Spring Boot ou Go-lang.org é o primeiro passo de ouro.
+- **Documentações Oficiais:** Ler os guias iniciais do Express.js, FastAPI, Spring Boot ou [Go](https://go.dev/) é o primeiro passo de ouro.
 
 **Para o Pleno (Arquitetura, Bancos e Testes):**
 - **[Hussein Nasser (YouTube)](https://www.youtube.com/@hnasr):** O melhor canal para aprender como os bancos de dados (Postgres, Redis, Kafka) e protocolos (TCP/UDP, HTTP/2/3) funcionam por baixo dos panos.
@@ -197,7 +197,7 @@ Para atingir a excelência em 2026, recomendamos os seguintes recursos práticos
 - **[ByteByteGo (Alex Xu)](https://bytebytego.com/):** O curso e livro definitivos sobre System Design ("System Design Interview"). Acompanhe também o canal no YouTube.
 - **[Arpit Bhayani (YouTube e Cursos)](https://www.youtube.com/@ArpitBhayani):** Focado em engenharia de altíssima escala e otimizações de nível de Kernel.
 - **[LangChain Academy](https://academy.langchain.com/) / [LlamaIndex Docs](https://docs.llamaindex.ai/):** Leituras obrigatórias para orquestração de Agentes e criação de arquiteturas RAG avançadas integradas com o banco de dados.
-- **The Rust Programming Language Book:** A introdução oficial para entender ownership, empréstimos e criar serviços seguros e ultra rápidos.
+- **[The Rust Programming Language Book](https://doc.rust-lang.org/book/):** A introdução oficial para entender ownership, empréstimos e criar serviços seguros e ultra rápidos.
 
 ---
 

--- a/roadmaps/backend/backend.md
+++ b/roadmaps/backend/backend.md
@@ -178,6 +178,29 @@ Para chegar ao nível especialista, a prática não basta. Você precisa de teor
 
 ---
 
+## 📚 Materiais de Estudo Recomendados
+
+Para atingir a excelência em 2026, recomendamos os seguintes recursos práticos e teóricos:
+
+**Para o Júnior (Fundamentos e Bases):**
+- **[Boot.dev](https://www.boot.dev/):** Plataforma incrível gamificada focada no backend (Python, Go, algoritmos e estruturas de dados).
+- **[FreeCodeCamp - Back End Development and APIs](https://www.freecodecamp.org/):** Excelente curso prático e gratuito sobre Node.js e MongoDB.
+- **Documentações Oficiais:** Ler os guias iniciais do Express.js, FastAPI, Spring Boot ou Go-lang.org é o primeiro passo de ouro.
+
+**Para o Pleno (Arquitetura, Bancos e Testes):**
+- **[Hussein Nasser (YouTube)](https://www.youtube.com/@hnasr):** O melhor canal para aprender como os bancos de dados (Postgres, Redis, Kafka) e protocolos (TCP/UDP, HTTP/2/3) funcionam por baixo dos panos.
+- **[Test-Driven Development with Python (Harry Percival)](https://www.obeythetestinggoat.com/):** Livro clássico (disponível de graça online) que ensina TDD de verdade com Django.
+- **[Full Cycle](https://fullcycle.com.br/):** Referência nacional para entender Docker, microsserviços, RabbitMQ e arquiteturas modernas para empresas.
+
+**Para o Sênior/Especialista (System Design, Rust, AI Engineering):**
+- **[Designing Data-Intensive Applications (Martin Kleppmann)](https://dataintensive.net/):** A bíblia absoluta do engenheiro de backend sênior. Ensina Replicação, Particionamento e Consenso.
+- **[ByteByteGo (Alex Xu)](https://bytebytego.com/):** O curso e livro definitivos sobre System Design ("System Design Interview"). Acompanhe também o canal no YouTube.
+- **[Arpit Bhayani (YouTube e Cursos)](https://www.youtube.com/@ArpitBhayani):** Focado em engenharia de altíssima escala e otimizações de nível de Kernel.
+- **[LangChain Academy](https://academy.langchain.com/) / [LlamaIndex Docs](https://docs.llamaindex.ai/):** Leituras obrigatórias para orquestração de Agentes e criação de arquiteturas RAG avançadas integradas com o banco de dados.
+- **The Rust Programming Language Book:** A introdução oficial para entender ownership, empréstimos e criar serviços seguros e ultra rápidos.
+
+---
+
 ## ↩️ Navegação
 
 *   [**Voltar para o Início**](../../index.md)

--- a/roadmaps/data/data-engineering.md
+++ b/roadmaps/data/data-engineering.md
@@ -130,7 +130,7 @@ Para atingir a excelência em 2026, recomendamos os seguintes recursos práticos
 
 **Para o Sênior/Especialista (Big Data, Lakehouse, Streaming e Governança):**
 - **[Data Engineering Zoomcamp (DataTalks.Club)](https://github.com/DataTalksClub/data-engineering-zoomcamp):** Bootcamp intensivo, de código aberto e comunitário do GitHub abrangendo Airflow, Kafka, Spark, Terraform e GCP/AWS. Absolutamente fantástico.
-- **Livro: "Designing Data-Intensive Applications" (Martin Kleppmann):** A leitura definitiva sobre bancos de dados distribuídos e transações, recomendada igualmente para Devs de Backend.
+- **[Designing Data-Intensive Applications (Martin Kleppmann)](https://dataintensive.net/):** A leitura definitiva sobre bancos de dados distribuídos e transações, recomendada igualmente para Devs de Backend.
 - **Livro: "Data Mesh: Delivering Data-Driven Value at Scale" (Zhamak Dehghani):** A criadora do conceito ensina arquiteturas descentralizadas corporativas focadas em escalabilidade e cultura.
 - **[Databricks Academy (Cursos de Lakehouse e Spark)](https://www.databricks.com/learn/training/home):** Mergulhe na fundação de um Data Lakehouse robusto via Apache Spark, Delta Lake e MLflow corporativo para integrar as equipes de Engenharia e IA de forma profissional.
 

--- a/roadmaps/data/data-engineering.md
+++ b/roadmaps/data/data-engineering.md
@@ -115,6 +115,27 @@ Dados com bugs geram modelos de IA perigosos. "Garbage in, Garbage out".
 
 ---
 
+## 📚 Materiais de Estudo Recomendados
+
+Para atingir a excelência em 2026, recomendamos os seguintes recursos práticos e teóricos:
+
+**Para o Júnior (SQL, Python, Modelagem Básico):**
+- **[DataCamp](https://www.datacamp.com/):** O lugar ideal (interativo no browser) para quem quer pegar intimidade prática com SQL, Python (Pandas/NumPy) e os primeiros passos para dados estruturados.
+- **[Kaggle](https://www.kaggle.com/):** A comunidade onde habitam os datasets. Baixe CSVs (filmes, temperatura do mundo, dados criminais), suba no Postgres/Colab e aprenda limpando a "sujeira" do mundo real.
+
+**Para o Pleno (ETL, dbt, Airflow e Warehouses):**
+- **[dbt Learn (Fundamentals)](https://courses.getdbt.com/):** O dbt (data build tool) é obrigatório hoje, e este curso oficial e gratuito de 5 horas ensina do zero o conceito do Analytics Engineering e ELT.
+- **[Marc Lamberti (Udemy/YouTube)](https://www.youtube.com/@marclamberti):** A referência suprema quando o assunto é Apache Airflow (orquestração corporativa).
+- **Livro: "Data Warehouse Toolkit" (Ralph Kimball):** Um livro das antigas, mas a modelagem dimensional (Star Schema) ainda dita as regras em ambientes BigQuery/Snowflake.
+
+**Para o Sênior/Especialista (Big Data, Lakehouse, Streaming e Governança):**
+- **[Data Engineering Zoomcamp (DataTalks.Club)](https://github.com/DataTalksClub/data-engineering-zoomcamp):** Bootcamp intensivo, de código aberto e comunitário do GitHub abrangendo Airflow, Kafka, Spark, Terraform e GCP/AWS. Absolutamente fantástico.
+- **Livro: "Designing Data-Intensive Applications" (Martin Kleppmann):** A leitura definitiva sobre bancos de dados distribuídos e transações, recomendada igualmente para Devs de Backend.
+- **Livro: "Data Mesh: Delivering Data-Driven Value at Scale" (Zhamak Dehghani):** A criadora do conceito ensina arquiteturas descentralizadas corporativas focadas em escalabilidade e cultura.
+- **[Databricks Academy (Cursos de Lakehouse e Spark)](https://www.databricks.com/learn/training/home):** Mergulhe na fundação de um Data Lakehouse robusto via Apache Spark, Delta Lake e MLflow corporativo para integrar as equipes de Engenharia e IA de forma profissional.
+
+---
+
 ## ↩️ Navegação
 
 *   [**Voltar para o Início**](../../index.md)

--- a/roadmaps/devops/devops.md
+++ b/roadmaps/devops/devops.md
@@ -124,6 +124,28 @@ DevOps é cultura, e cultura se aprende com histórias e práticas.
 
 ---
 
+## 📚 Materiais de Estudo Recomendados
+
+Para atingir a excelência em 2026, recomendamos os seguintes recursos práticos e teóricos:
+
+**Para o Júnior (Fundamentos, Linux, Docker):**
+- **[KodeKloud](https://kodekloud.com/):** A melhor plataforma hands-on (prática no terminal) para aprender Linux, Docker e Git, com cenários simulados fantásticos.
+- **[NetworkChuck (YouTube)](https://www.youtube.com/@NetworkChuck):** Canal muito didático e acessível para quem precisa começar no mundo das redes, subnetting, e roteadores.
+- **[ACloudGuru (agora Pluralsight)](https://www.pluralsight.com/cloud-guru):** O clássico absoluto para certificações Cloud Practioner da AWS, GCP e Azure.
+
+**Para o Pleno (Cloud, CI/CD, Terraform e Kubernetes):**
+- **[Nana Janashia (TechWorld with Nana)](https://www.youtube.com/@TechWorldwithNana):** Um canal essencial. Os "Crash Courses" gratuitos sobre Terraform, Ansible, Docker e Kubernetes são de ouro.
+- **[KubeAcademy (VMware)](https://kube.academy/):** Cursos curtos e gratuitos e bem desenhados focados nos mínimos detalhes do ecossistema Kubernetes.
+- **[AWS Skill Builder](https://explore.skillbuilder.aws/):** Utilize a plataforma oficial da AWS e seu lab guiado para aprender a conectar lambdas com redes sem medo.
+
+**Para o Sênior/Especialista (eBPF, FinOps, GitOps e IDPs):**
+- **[The Phoenix Project / The DevOps Handbook (Livros)](https://itrevolution.com/):** Não subestime a parte humana e cultural, estes são as "Bíblias" que orientam Staff Engineers na jornada de DevOps corporativa.
+- **[eBPF.io - O portal oficial do eBPF](https://ebpf.io/):** Documentação profunda, papers de arquitetura, e exemplos de programação em Rust/C para criar os próximos programas do kernel.
+- **[ArgoCD / Flux Docs](https://argo-cd.readthedocs.io/):** O guia mais atualizado para escalar GitOps real e contínuo.
+- **[CNCF (Cloud Native Computing Foundation) Landscape](https://landscape.cncf.io/):** Mapeamento atualizado anualmente pela fundação, focando em ferramentas mantidas e criadas pelas empresas top tier. Navegue nos projetos (Graduados) de segurança (Trivy), Observabilidade (OpenTelemetry), e Proxies (Envoy).
+
+---
+
 ## ↩️ Navegação
 
 *   [**Voltar para o Início**](../../index.md)

--- a/roadmaps/devops/devops.md
+++ b/roadmaps/devops/devops.md
@@ -131,7 +131,7 @@ Para atingir a excelência em 2026, recomendamos os seguintes recursos práticos
 **Para o Júnior (Fundamentos, Linux, Docker):**
 - **[KodeKloud](https://kodekloud.com/):** A melhor plataforma hands-on (prática no terminal) para aprender Linux, Docker e Git, com cenários simulados fantásticos.
 - **[NetworkChuck (YouTube)](https://www.youtube.com/@NetworkChuck):** Canal muito didático e acessível para quem precisa começar no mundo das redes, subnetting, e roteadores.
-- **[ACloudGuru (agora Pluralsight)](https://www.pluralsight.com/cloud-guru):** O clássico absoluto para certificações Cloud Practioner da AWS, GCP e Azure.
+- **[ACloudGuru (agora Pluralsight)](https://www.pluralsight.com/cloud-guru):** O clássico absoluto para certificações Cloud Practitioner da AWS, GCP e Azure.
 
 **Para o Pleno (Cloud, CI/CD, Terraform e Kubernetes):**
 - **[Nana Janashia (TechWorld with Nana)](https://www.youtube.com/@TechWorldwithNana):** Um canal essencial. Os "Crash Courses" gratuitos sobre Terraform, Ansible, Docker e Kubernetes são de ouro.
@@ -139,7 +139,7 @@ Para atingir a excelência em 2026, recomendamos os seguintes recursos práticos
 - **[AWS Skill Builder](https://explore.skillbuilder.aws/):** Utilize a plataforma oficial da AWS e seu lab guiado para aprender a conectar lambdas com redes sem medo.
 
 **Para o Sênior/Especialista (eBPF, FinOps, GitOps e IDPs):**
-- **[The Phoenix Project / The DevOps Handbook (Livros)](https://itrevolution.com/):** Não subestime a parte humana e cultural, estes são as "Bíblias" que orientam Staff Engineers na jornada de DevOps corporativa.
+- **[The Phoenix Project / The DevOps Handbook (Livros)](https://itrevolution.com/):** Não subestime a parte humana e cultural, estas são as "Bíblias" que orientam Staff Engineers na jornada de DevOps corporativa.
 - **[eBPF.io - O portal oficial do eBPF](https://ebpf.io/):** Documentação profunda, papers de arquitetura, e exemplos de programação em Rust/C para criar os próximos programas do kernel.
 - **[ArgoCD / Flux Docs](https://argo-cd.readthedocs.io/):** O guia mais atualizado para escalar GitOps real e contínuo.
 - **[CNCF (Cloud Native Computing Foundation) Landscape](https://landscape.cncf.io/):** Mapeamento atualizado anualmente pela fundação, focando em ferramentas mantidas e criadas pelas empresas top tier. Navegue nos projetos (Graduados) de segurança (Trivy), Observabilidade (OpenTelemetry), e Proxies (Envoy).

--- a/roadmaps/frontend/frontend.md
+++ b/roadmaps/frontend/frontend.md
@@ -134,6 +134,28 @@ A web consome energia. Você pode ajudar a reduzir isso.
 
 ---
 
+## 📚 Materiais de Estudo Recomendados
+
+Para atingir a excelência em 2026, recomendamos os seguintes recursos práticos e teóricos:
+
+**Para o Júnior (Fundamentos e Bases):**
+- **MDN Web Docs:** A bíblia do desenvolvimento web. Sempre consulte a MDN antes do StackOverflow.
+- **[FreeCodeCamp - Responsive Web Design](https://www.freecodecamp.org/):** Excelente para fixar HTML e CSS na prática.
+- **[JavaScript.info](https://javascript.info/):** O guia mais completo para entender o JS moderno a fundo.
+
+**Para o Pleno (Arquitetura e TypeScript):**
+- **[Total TypeScript](https://www.totaltypescript.com/):** O curso definitivo para parar de brigar com o compilador e entender TypeScript avançado (Matt Pocock).
+- **[Frontend Masters](https://frontendmasters.com/):** Cursos aprofundados sobre performance, acessibilidade e algoritmos no frontend.
+- **[Epic React](https://epicreact.dev/) / [React.dev](https://react.dev/):** Domine os padrões do React, concorrência e o novo React Compiler.
+
+**Para o Sênior/Especialista (Generative UI, Performance e WebGPU):**
+- **[web.dev (Google Chrome Developers)](https://web.dev/):** Acompanhe as métricas vitais (Core Web Vitals), novidades de CSS e arquitetura moderna.
+- **[Vercel AI SDK Documentation](https://sdk.vercel.ai/docs):** Essencial para implementar Generative UI e integrar RAG no Frontend via React Server Components.
+- **[Patterns.dev](https://www.patterns.dev/):** O guia moderno definitivo para padrões de design (Design Patterns) em JavaScript e React, focado em performance.
+- **[Josh W. Comeau's CSS for JS Devs](https://css-for-js.dev/):** Se você foge do CSS e usa apenas Tailwind, este curso muda a sua mente, ensinando o motor do CSS por trás dos panos.
+
+---
+
 ## ↩️ Navegação
 
 *   [**Voltar para o Início**](../../index.md)

--- a/roadmaps/frontend/frontend.md
+++ b/roadmaps/frontend/frontend.md
@@ -139,7 +139,7 @@ A web consome energia. Você pode ajudar a reduzir isso.
 Para atingir a excelência em 2026, recomendamos os seguintes recursos práticos e teóricos:
 
 **Para o Júnior (Fundamentos e Bases):**
-- **MDN Web Docs:** A bíblia do desenvolvimento web. Sempre consulte a MDN antes do StackOverflow.
+- **[MDN Web Docs](https://developer.mozilla.org/):** A bíblia do desenvolvimento web. Sempre consulte a MDN antes do StackOverflow.
 - **[FreeCodeCamp - Responsive Web Design](https://www.freecodecamp.org/):** Excelente para fixar HTML e CSS na prática.
 - **[JavaScript.info](https://javascript.info/):** O guia mais completo para entender o JS moderno a fundo.
 

--- a/roadmaps/fullstack/fullstack.md
+++ b/roadmaps/fullstack/fullstack.md
@@ -130,8 +130,8 @@ Para atingir a excelência em 2026, recomendamos os seguintes recursos práticos
 **Para o Sênior/Especialista (Edge Computing, Local-First e IA):**
 - **[Vercel AI SDK & Next.js AI Chatbot](https://github.com/vercel/ai-chatbot):** Estude o código-fonte desse repositório para entender como arquitetar e deployar o que há de mais moderno em GenUI com Server Actions.
 - **[Local-First Web Development (Automerge / Yjs Docs)](https://localfirstweb.dev/):** Este manifesto explica a arquitetura necessária para as aplicações offline-first premium de 2026. Leia e acompanhe projetos como o PowerSync.
-- **[Turborepo e Nx Docs](https://turbo.build/):** O padrão para criar monorepos eficientes, essenciais para dividir componentes entre projetos Admin, API e App Cliente.
-- **[Serverless Framework / SST (Serverless Stack)](https://sst.dev/):** Guias arquitetônicos excelentes de como desenhar pipelines nativos de Nuvem (AWS Lambda, DynamoDB) a partir de uma base de código unificada (TypeScript/Next.js).
+- **[Turborepo](https://turbo.build/) e [Nx](https://nx.dev/) Docs:** O padrão para criar monorepos eficientes, essenciais para dividir componentes entre projetos Admin, API e App Cliente.
+- **[Serverless Framework](https://www.serverless.com/) / [SST (Serverless Stack)](https://sst.dev/):** Guias arquitetônicos excelentes de como desenhar pipelines nativos de Nuvem (AWS Lambda, DynamoDB) a partir de uma base de código unificada (TypeScript/Next.js).
 
 ---
 

--- a/roadmaps/fullstack/fullstack.md
+++ b/roadmaps/fullstack/fullstack.md
@@ -114,6 +114,27 @@ A integração profunda de modelos de IA no produto.
 
 ---
 
+## 📚 Materiais de Estudo Recomendados
+
+Para atingir a excelência em 2026, recomendamos os seguintes recursos práticos e teóricos:
+
+**Para o Júnior (Fundamentos e Bases):**
+- **[The Odin Project](https://www.theodinproject.com/):** O melhor currículo gratuito e guiado por projetos para full stack (Ruby on Rails ou Node.js).
+- **[Full Stack Open (Universidade de Helsinque)](https://fullstackopen.com/):** Curso maravilhoso focado em React, Redux, Node.js, MongoDB, GraphQL e TypeScript.
+
+**Para o Pleno (Next.js, Arquitetura e Monorepos):**
+- **[Next.js Learn (Curso Oficial)](https://nextjs.org/learn):** A documentação da Vercel tem um curso passo a passo criando um dashboard full stack. Imperdível.
+- **[Prisma / Drizzle Docs](https://www.prisma.io/docs):** Aprenda ORMs modernos lendo os guias iniciais e tutorias práticos em seus sites oficiais.
+- **[Joy of React (Josh Comeau)](https://joyofreact.com/):** Uma profunda exploração das fundações do React, excelente para consolidar conceitos antes de tentar construir apps complexos.
+
+**Para o Sênior/Especialista (Edge Computing, Local-First e IA):**
+- **[Vercel AI SDK & Next.js AI Chatbot](https://github.com/vercel/ai-chatbot):** Estude o código-fonte desse repositório para entender como arquitetar e deployar o que há de mais moderno em GenUI com Server Actions.
+- **[Local-First Web Development (Automerge / Yjs Docs)](https://localfirstweb.dev/):** Este manifesto explica a arquitetura necessária para as aplicações offline-first premium de 2026. Leia e acompanhe projetos como o PowerSync.
+- **[Turborepo e Nx Docs](https://turbo.build/):** O padrão para criar monorepos eficientes, essenciais para dividir componentes entre projetos Admin, API e App Cliente.
+- **[Serverless Framework / SST (Serverless Stack)](https://sst.dev/):** Guias arquitetônicos excelentes de como desenhar pipelines nativos de Nuvem (AWS Lambda, DynamoDB) a partir de uma base de código unificada (TypeScript/Next.js).
+
+---
+
 ## ↩️ Navegação
 
 *   [**Voltar para o Início**](../../index.md)

--- a/roadmaps/mobile/mobile.md
+++ b/roadmaps/mobile/mobile.md
@@ -136,7 +136,7 @@ Para atingir a excelência em 2026, recomendamos os seguintes recursos práticos
 **Para o Júnior (Fundamentos e Bases):**
 - **Cursos Oficiais Android e iOS:** As plataformas de documentação da [Apple (Swift Playgrounds)](https://developer.apple.com/swift/) e [Google (Android Codelabs)](https://developer.android.com/courses) são os melhores lugares absolutos para iniciar.
 - **[Flutter.dev (Documentação Oficial)](https://flutter.dev/):** Considerado o melhor guia para entrar no mundo Mobile Híbrido, repleto de "Codelabs" práticos.
-- **[React Native - Core Components](https://reactnative.dev/docs/intro):** Se você veio do mundo React, a documentação oficial sobre componentes principais vai acelerar seus estudos.
+- **[React Native - Core Components](https://reactnative.dev/docs/components-and-apis):** Se você veio do mundo React, a documentação oficial sobre componentes principais vai acelerar seus estudos.
 
 **Para o Pleno (Arquitetura, Gerenciamento e Conexão):**
 - **[Philipp Lackner (YouTube)](https://www.youtube.com/@PhilippLackner):** Excelente para aprender Kotlin moderno, Jetpack Compose e as melhores práticas do Android.
@@ -147,7 +147,7 @@ Para atingir a excelência em 2026, recomendamos os seguintes recursos práticos
 - **[ExecuTorch Docs (PyTorch)](https://pytorch.org/executorch):** Aprenda como preparar grandes modelos LLM/SLM e rodar de forma leve nos dispositivos móveis.
 - **[Hugging Face Spaces - Local/On-Device AI](https://huggingface.co/spaces):** Acompanhe modelos como o Llama.cpp adaptado para iOS/Android e WebNN, além do Transformers.js rodando em React Native.
 - **[Kotlin Multiplatform (KMP) by JetBrains](https://kotlinlang.org/docs/multiplatform.html):** Documentação técnica que explica como compartilhar lógicas de negócio C++/Kotlin entre iOS/Android em larga escala.
-- **[DittoLive / PowerSync Docs](https://www.powersync.com/):** Aprenda na prática a projetar e sincronizar bancos de dados Local-First, essencial para arquiteturas Resilientes.
+- **[Ditto](https://www.ditto.live/) / [PowerSync](https://www.powersync.com/) Docs:** Aprenda na prática a projetar e sincronizar bancos de dados Local-First, essencial para arquiteturas Resilientes.
 
 ---
 

--- a/roadmaps/mobile/mobile.md
+++ b/roadmaps/mobile/mobile.md
@@ -129,6 +129,28 @@ Apps mal otimizados matam a bateria e geram lixo eletrônico (troca de aparelhos
 
 ---
 
+## 📚 Materiais de Estudo Recomendados
+
+Para atingir a excelência em 2026, recomendamos os seguintes recursos práticos e teóricos:
+
+**Para o Júnior (Fundamentos e Bases):**
+- **Cursos Oficiais Android e iOS:** As plataformas de documentação da [Apple (Swift Playgrounds)](https://developer.apple.com/swift/) e [Google (Android Codelabs)](https://developer.android.com/courses) são os melhores lugares absolutos para iniciar.
+- **[Flutter.dev (Documentação Oficial)](https://flutter.dev/):** Considerado o melhor guia para entrar no mundo Mobile Híbrido, repleto de "Codelabs" práticos.
+- **[React Native - Core Components](https://reactnative.dev/docs/intro):** Se você veio do mundo React, a documentação oficial sobre componentes principais vai acelerar seus estudos.
+
+**Para o Pleno (Arquitetura, Gerenciamento e Conexão):**
+- **[Philipp Lackner (YouTube)](https://www.youtube.com/@PhilippLackner):** Excelente para aprender Kotlin moderno, Jetpack Compose e as melhores práticas do Android.
+- **[Vanderbilt University - Coursera (Android App Development)](https://www.coursera.org/specializations/android-app-development):** Uma base estruturada maravilhosa.
+- **[Andrea Bizzotto (Flutter)](https://codewithandrea.com/):** O melhor material avançado e atualizado sobre arquitetura no Flutter (Riverpod, Clean Architecture).
+
+**Para o Sênior/Especialista (On-Device AI, NPU, Compose Multiplatform):**
+- **[ExecuTorch Docs (PyTorch)](https://pytorch.org/executorch):** Aprenda como preparar grandes modelos LLM/SLM e rodar de forma leve nos dispositivos móveis.
+- **[Hugging Face Spaces - Local/On-Device AI](https://huggingface.co/spaces):** Acompanhe modelos como o Llama.cpp adaptado para iOS/Android e WebNN, além do Transformers.js rodando em React Native.
+- **[Kotlin Multiplatform (KMP) by JetBrains](https://kotlinlang.org/docs/multiplatform.html):** Documentação técnica que explica como compartilhar lógicas de negócio C++/Kotlin entre iOS/Android em larga escala.
+- **[DittoLive / PowerSync Docs](https://www.powersync.com/):** Aprenda na prática a projetar e sincronizar bancos de dados Local-First, essencial para arquiteturas Resilientes.
+
+---
+
 ## ↩️ Navegação
 
 *   [**Voltar para o Início**](../../index.md)

--- a/roadmaps/qa/qa-testing.md
+++ b/roadmaps/qa/qa-testing.md
@@ -95,6 +95,26 @@ O QA não será substituído pela IA, mas o QA que usa IA substituirá o que nã
 
 ---
 
+## 📚 Materiais de Estudo Recomendados
+
+Para atingir a excelência em 2026, recomendamos os seguintes recursos práticos e teóricos:
+
+**Para o Júnior (Fundamentos e Teste Manual):**
+- **[Syllabus CTFL (ISTQB)](https://bstqb.org.br/):** O currículo oficial de certificação internacional, fornecendo a teoria base em testes de qualidade que vai diferenciar a base do júnior.
+- **[FreeCodeCamp - Software Testing Course](https://www.freecodecamp.org/):** Excelente curso prático gratuito com vídeos sobre o ciclo de vida do software e tipos de teste para um testador iniciante.
+
+**Para o Pleno (Automação Web E2E, APIs):**
+- **[Documentação Oficial do Playwright](https://playwright.dev/):** A melhor documentação entre as ferramentas de QA atuais. Leia o "Getting Started" e os guias fundamentais (Locators e Assertions).
+- **[Cypress Real World App (Repo GitHub)](https://github.com/cypress-io/cypress-realworld-app):** A Cypress forneceu este repositório de um App clone inteiro com os melhores exemplos práticos de como automatizar pagamentos e criar testes escaláveis.
+- **[Ministry of Testing (MoT)](https://www.ministryoftesting.com/):** Uma comunidade mundial riquíssima que aborda os desafios práticos do engenheiro QA além do código.
+
+**Para o Sênior/Especialista (Testes de Performance, IA e Shift-Left):**
+- **[Grafana k6 Docs](https://k6.io/docs/):** A ferramenta moderna baseada em Javascript/Go para aplicar carga, picos massivos e verificar "Testes de Stress" contra APIs da arquitetura Backend.
+- **[Test Automation University (Applitools)](https://testautomationu.applitools.com/):** Uma infinidade de cursos gratuitos, avançados (em Java/Python/Javascript), sobre testes visuais impulsionados por IA (Visual AI).
+- **[The Pragmatic Engineer (Newsletter/Blog)](https://blog.pragmaticengineer.com/):** Ótimo para um QA Sênior entender as estratégias massivas que empresas (Uber, Stripe) tomam sobre "Engineering Productivity" em vez de apenas achar bugs.
+
+---
+
 ## ↩️ Navegação
 
 *   [**Voltar para o Início**](../../index.md)

--- a/roadmaps/qa/qa-testing.md
+++ b/roadmaps/qa/qa-testing.md
@@ -109,8 +109,8 @@ Para atingir a excelência em 2026, recomendamos os seguintes recursos práticos
 - **[Ministry of Testing (MoT)](https://www.ministryoftesting.com/):** Uma comunidade mundial riquíssima que aborda os desafios práticos do engenheiro QA além do código.
 
 **Para o Sênior/Especialista (Testes de Performance, IA e Shift-Left):**
-- **[Grafana k6 Docs](https://k6.io/docs/):** A ferramenta moderna baseada em Javascript/Go para aplicar carga, picos massivos e verificar "Testes de Stress" contra APIs da arquitetura Backend.
-- **[Test Automation University (Applitools)](https://testautomationu.applitools.com/):** Uma infinidade de cursos gratuitos, avançados (em Java/Python/Javascript), sobre testes visuais impulsionados por IA (Visual AI).
+- **[Grafana k6 Docs](https://k6.io/docs/):** A ferramenta moderna baseada em JavaScript/Go para aplicar carga, picos massivos e verificar "Testes de Stress" contra APIs da arquitetura Backend.
+- **[Test Automation University (Applitools)](https://testautomationu.applitools.com/):** Uma infinidade de cursos gratuitos, avançados (em Java/Python/JavaScript), sobre testes visuais impulsionados por IA (Visual AI).
 - **[The Pragmatic Engineer (Newsletter/Blog)](https://blog.pragmaticengineer.com/):** Ótimo para um QA Sênior entender as estratégias massivas que empresas (Uber, Stripe) tomam sobre "Engineering Productivity" em vez de apenas achar bugs.
 
 ---

--- a/roadmaps/security/cybersecurity.md
+++ b/roadmaps/security/cybersecurity.md
@@ -114,6 +114,28 @@ Onde há código, há vulnerabilidade. A Inteligência Artificial trouxe um ocea
 
 ---
 
+## 📚 Materiais de Estudo Recomendados
+
+Para atingir a excelência em 2026, recomendamos os seguintes recursos práticos e teóricos:
+
+**Para o Júnior (Redes, Linux e Fundamentos de Cyber):**
+- **[TryHackMe](https://tryhackme.com/):** A forma mais didática do mundo para aprender e práticar Redes (Nmap, Wireshark), Linux e as técnicas ofensivas/defensivas gamificadas. É mandatório para o Júnior.
+- **[Professor Messer (CompTIA Security+ / Network+)](https://www.youtube.com/@professormesser):** Cursos gratuitos incríveis que englobam todo o syllabus fundamental da teoria e jargões da segurança em nuvem, encriptação e hardware.
+- **[OverTheWire (Bandit)](https://overthewire.org/wargames/bandit/):** Um wargame muito querido na comunidade, ensina o aluno a utilizar um terminal bash com confiança para as etapas mais avançadas.
+
+**Para o Pleno (AppSec, Pentesting e Cloud):**
+- **[HackTheBox](https://www.hackthebox.com/):** A principal arena focada em atacar caixas (servidores virtuais). Exige esforço e persistência. Comece através dos tutoriais do HTB Academy antes.
+- **[PortSwigger Web Security Academy](https://portswigger.net/web-security):** Criado pelos desenvolvedores do famosíssimo *Burp Suite*. É o lugar definitivo para aprender exploração Web moderna baseada nos Top 10 vulnerabilidades.
+- **[OWASP Top 10 (Site Oficial)](https://owasp.org/www-project-top-ten/):** Aprenda detalhadamente os defeitos corporativos comuns que mais causam roubo de informações confidenciais do servidor aos cookies no Browser.
+
+**Para o Sênior/Especialista (AI Red Teaming, Pós-Quântica, DevSecOps):**
+- **[OWASP Top 10 for Large Language Models](https://owasp.org/www-project-top-10-for-large-language-models/):** Leitura de suma importância se você quer proteger prompts e gerenciar *data poisoning* no Backend da IA Corporativa do seu time.
+- **[NIST Post-Quantum Cryptography Guidelines](https://csrc.nist.gov/projects/post-quantum-cryptography):** Entenda as padronizações FIPS oficiais do governo americano de 2024 que os sistemas bancários em 2026 são ordenados a utilizar para impedir espionagem retroativa.
+- **[Snyk (DevSecOps Platform) / Trivy Documentation](https://snyk.io/learn/):** Plataforma incrível para entender "Shift-Left", containers, infraestrutura de vulnerabilidades em repositórios Git, mitigando o NPM falso e vazamentos do Github.
+- **[PicoCTF (Carnegie Mellon University)](https://picoctf.org/):** Jogue Capture The Flag de alta classe universitária e foque intensamente em "Reverse Engineering", "Binary Exploitation" e Criptografia.
+
+---
+
 ## ↩️ Navegação
 
 *   [**Voltar para o Início**](../../index.md)

--- a/roadmaps/security/cybersecurity.md
+++ b/roadmaps/security/cybersecurity.md
@@ -119,7 +119,7 @@ Onde há código, há vulnerabilidade. A Inteligência Artificial trouxe um ocea
 Para atingir a excelência em 2026, recomendamos os seguintes recursos práticos e teóricos:
 
 **Para o Júnior (Redes, Linux e Fundamentos de Cyber):**
-- **[TryHackMe](https://tryhackme.com/):** A forma mais didática do mundo para aprender e práticar Redes (Nmap, Wireshark), Linux e as técnicas ofensivas/defensivas gamificadas. É mandatório para o Júnior.
+- **[TryHackMe](https://tryhackme.com/):** A forma mais didática do mundo para aprender e praticar Redes (Nmap, Wireshark), Linux e as técnicas ofensivas/defensivas gamificadas. É mandatório para o Júnior.
 - **[Professor Messer (CompTIA Security+ / Network+)](https://www.youtube.com/@professormesser):** Cursos gratuitos incríveis que englobam todo o syllabus fundamental da teoria e jargões da segurança em nuvem, encriptação e hardware.
 - **[OverTheWire (Bandit)](https://overthewire.org/wargames/bandit/):** Um wargame muito querido na comunidade, ensina o aluno a utilizar um terminal bash com confiança para as etapas mais avançadas.
 
@@ -131,7 +131,7 @@ Para atingir a excelência em 2026, recomendamos os seguintes recursos práticos
 **Para o Sênior/Especialista (AI Red Teaming, Pós-Quântica, DevSecOps):**
 - **[OWASP Top 10 for Large Language Models](https://owasp.org/www-project-top-10-for-large-language-models/):** Leitura de suma importância se você quer proteger prompts e gerenciar *data poisoning* no Backend da IA Corporativa do seu time.
 - **[NIST Post-Quantum Cryptography Guidelines](https://csrc.nist.gov/projects/post-quantum-cryptography):** Entenda as padronizações FIPS oficiais do governo americano de 2024 que os sistemas bancários em 2026 são ordenados a utilizar para impedir espionagem retroativa.
-- **[Snyk (DevSecOps Platform) / Trivy Documentation](https://snyk.io/learn/):** Plataforma incrível para entender "Shift-Left", containers, infraestrutura de vulnerabilidades em repositórios Git, mitigando o NPM falso e vazamentos do Github.
+- **[Snyk (DevSecOps Platform) / Trivy Documentation](https://snyk.io/learn/):** Plataforma incrível para entender "Shift-Left", containers, infraestrutura de vulnerabilidades em repositórios Git, mitigando o NPM falso e vazamentos do GitHub.
 - **[PicoCTF (Carnegie Mellon University)](https://picoctf.org/):** Jogue Capture The Flag de alta classe universitária e foque intensamente em "Reverse Engineering", "Binary Exploitation" e Criptografia.
 
 ---


### PR DESCRIPTION
Appended a "📚 Materiais de Estudo Recomendados" section to all domain-specific roadmaps (Frontend, Backend, Full Stack, Mobile, DevOps, Data, Security, AI, QA). The resources are categorized by developer level (Júnior, Pleno, Sênior/Especialista) and align with the 2026 completeness goal. Also verified that the VitePress site builds successfully with the updated markdown files.

---
*PR created automatically by Jules for task [13532611716765379202](https://jules.google.com/task/13532611716765379202) started by @juninmd*