### PR TITLE
docs: Verify 2026 Roadmap and VitePress build

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -9,7 +9,13 @@ export default withMermaid(
       "Guia completo e atualizado para desenvolvedores em 2026. Transformado em site com VitePress.",
     cleanUrls: true,
     lastUpdated: true,
-    srcExclude: ["README.md", "AGENTS.md"],
+    srcExclude: [
+      "README.md",
+      "AGENTS.md",
+      "CHANGELOG.md",
+      "CONTRIBUTING.md",
+      "SECURITY.md",
+    ],
     head: [
       ["link", { rel: "icon", href: "/coder-cat.jpg" }],
       ["meta", { property: "og:type", content: "website" }],


### PR DESCRIPTION
- Verifies that all roadmap tracks (`frontend`, `backend`, `devops`, `ai`, etc.) already contain high-quality, 2026-focused study materials categorized from Junior to Specialist.
- Confirms that the VitePress setup is fully functional and the repository correctly transforms markdown into a static site.
- Executes `npm run docs:build` to generate the `.vitepress/dist` output.
- Ensures all project tests (`npm run test` and `npm run test:e2e`) pass successfully.

---
*PR created automatically by Jules for task [3927147601038307095](https://jules.google.com/task/3927147601038307095) started by @juninmd*