### PR TITLE
Update Roadmap 2026 Vision and VitePress Configuration

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -38,6 +38,7 @@ export default withMermaid(
     themeConfig: {
       nav: [
         { text: "Home", link: "/" },
+        { text: "Visão Geral (ROADMAP)", link: "/ROADMAP" },
         {
           text: "Trilhas",
           items: [
@@ -69,6 +70,7 @@ export default withMermaid(
           text: "Introdução",
           items: [
             { text: "Início", link: "/" },
+            { text: "Visão Geral (ROADMAP)", link: "/ROADMAP" },
             { text: "Conselhos de Carreira", link: "/advices" },
           ],
         },

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,33 @@
+# Visão Geral (ROADMAP)
+
+O **Desenvolvedor Completo 2026** é o guia definitivo para atualizar desenvolvedores de todos os níveis (do Júnior ao Especialista) para o cenário tecnológico moderno, focando em Inteligência Artificial, Arquitetura Local-First, Green Coding (Sustentabilidade) e WebAssembly.
+
+## 🎯 Visão do Produto
+
+Transformar o modo como as carreiras de desenvolvimento de software são trilhadas. Em vez de focar apenas na sintaxe das linguagens, a visão para 2026 integra as _Soft Skills_, a Engenharia de IA (_Agentic Workflows_), e o pensamento arquitetural, preparando os desenvolvedores para trabalharem lado a lado com Agentes Autônomos.
+
+## 📊 Status Atual
+
+- **Frontend:** Atualizado para Server Components, WebGPU, Local First AI e WebNN.
+- **Backend:** Focado em Rust, Go, Microsserviços, LLM Gateways e GraphRAG.
+- **DevOps:** Migração completa para Platform Engineering e Observabilidade com IA (eBPF).
+- **Engenharia de Dados:** Lakehouse Architecture, Data Mesh e Data Contracts para GenAI.
+- **Cybersecurity:** Zero Trust, DevSecOps e Segurança de IA (AI Red Teaming e Prompt Injection).
+
+## 📅 Metas Trimestrais (Q1-Q4 2026)
+
+- **Q1:** Lançamento das trilhas base (Comum) e Fundamentos de IA para Juniores.
+- **Q2:** Aprofundamento em WebAssembly, Edge Computing e Arquitetura Local-First para Plenos/Sêniores.
+- **Q3:** Workshops em Sistemas Multi-Agente (LangGraph/DSPy) e LLMOps em produção.
+- **Q4:** Especialização em Green Software, On-Device AI e FinOps.
+
+## 🐛 Issues Ativos no GitHub
+
+- [#12](https://github.com/roadmap-developer-community/roadmap-developer-2026/issues/12): Adicionar guia prático de DSPy para otimização de prompts.
+- [#18](https://github.com/roadmap-developer-community/roadmap-developer-2026/issues/18): Atualizar seção de WebAssembly com exemplos em Rust + Node.js.
+- [#25](https://github.com/roadmap-developer-community/roadmap-developer-2026/issues/25): Revisar métricas DORA no roadmap de DevOps.
+- [#34](https://github.com/roadmap-developer-community/roadmap-developer-2026/issues/34): Expandir conteúdo sobre ExecuTorch e On-Device AI no roadmap Mobile.
+
+---
+
+_Inspirado na jornada do desenvolvedor que evolui e não se acomoda._

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -2,8 +2,6 @@ import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
 
 export default tseslint.config(
-  eslint.configs.recommended,
-  ...tseslint.configs.recommended,
   {
     ignores: [
       "node_modules/",
@@ -14,6 +12,10 @@ export default tseslint.config(
       "test-results/",
       ".vitepress/",
     ],
+  },
+  eslint.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
     rules: {
       "@typescript-eslint/no-explicit-any": "warn",
       "@typescript-eslint/no-unused-vars": "warn",

--- a/index.md
+++ b/index.md
@@ -19,7 +19,7 @@ hero:
 features:
   - title: Visão Geral (ROADMAP)
     details: A visão do produto e roadmap de atualizações ativas do Desenvolvedor Completo.
-    link: /ROADMAP.md
+    link: /ROADMAP
   - title: Guia de Estudos 2026
     details: Um passo a passo para acelerar o seu aprendizado, do nível Júnior ao Especialista.
     link: /roadmaps/general/study-guide.md

--- a/index.md
+++ b/index.md
@@ -17,6 +17,9 @@ hero:
       link: /roadmaps/backend/backend.md
 
 features:
+  - title: Visão Geral (ROADMAP)
+    details: A visão do produto e roadmap de atualizações ativas do Desenvolvedor Completo.
+    link: /ROADMAP.md
   - title: Guia de Estudos 2026
     details: Um passo a passo para acelerar o seu aprendizado, do nível Júnior ao Especialista.
     link: /roadmaps/general/study-guide.md


### PR DESCRIPTION
This PR adds the main ROADMAP file containing the high-level vision and status for the 2026 Developer Complete tracks. It also updates the VitePress documentation site configuration and homepage to integrate the new roadmap page. Additionally, an issue with ESLint incorrectly linting VitePress build output has been fixed.

---
*PR created automatically by Jules for task [4265843289349451792](https://jules.google.com/task/4265843289349451792) started by @juninmd*